### PR TITLE
feat: 라벨 및 폼로우 컴포넌트 구현(#49)

### DIFF
--- a/src/components/common/FormRow.tsx
+++ b/src/components/common/FormRow.tsx
@@ -1,0 +1,34 @@
+import Label from '@components/common/Label'
+import { cn } from '@utils/cn'
+
+type FormRowProps = {
+  labelText: string
+  htmlFor: string
+  labelClassName?: string
+  valueClassName?: string
+  children: React.ReactNode
+}
+
+// 보더 없이 pr??
+const FormRow = ({
+  labelText,
+  htmlFor,
+  labelClassName,
+  valueClassName,
+  children,
+}: FormRowProps) => {
+  return (
+    <div className="inline-flex h-[50px] items-center border-t border-[#DDD]">
+      <Label
+        htmlFor={htmlFor}
+        labelText={labelText}
+        className={labelClassName}
+      />
+      <div className={cn('w-[530px] pl-[14px]', valueClassName)}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export default FormRow

--- a/src/components/common/Label.tsx
+++ b/src/components/common/Label.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@utils/cn'
+// 수정 뭐했는지 체크
+type LabelProps = {
+  htmlFor: string
+  labelText: string
+  className?: string
+}
+
+const Label = ({ htmlFor, labelText, className }: LabelProps) => {
+  return (
+    <label
+      htmlFor={htmlFor}
+      className={cn(
+        'flex h-full w-[200px] items-center bg-[#F7F7F7] px-[22px] text-[14px] text-[#222]',
+        className
+      )}
+    >
+      {labelText}
+    </label>
+  )
+}
+
+export default Label


### PR DESCRIPTION

## #️⃣연관된 이슈

> #49

## 📝작업 내용

- 라벨 컴포넌트 구현
- 라벨과 인풋, 드롭다운 등의 요소를 묶어주고 각 요소의 너비를 조정할 수 있는  폼로우 컴포넌트 구현 
- labelClassName: 왼쪽 칸 너비 지정, valueClassName: 오른쪽 칸 너비 지정 prop

