### PR TITLE
feat: 쪽지시험 페이지 라우팅 추가(#56)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,10 +6,20 @@ import { Routes, Route } from 'react-router'
 import Layout from '@components/Layout'
 import Main from '@pages/Main'
 import NotFound from '@pages/NotFound'
+import Quizzes from '@pages/quizzes/quizzes'
+import Deployments from '@pages/quizzes/Deployments'
+import Submissions from '@pages/quizzes/Submissions'
+import Dashboard from '@pages/quizzes/Dashboard'
 
 function App() {
   const ROUTES = [
     { element: <Main />, path: '/' },
+    // Quiz
+    { element: <Quizzes />, path: '/quizzes' },
+    { element: <Deployments />, path: '/quizzes/deployments' },
+    { element: <Submissions />, path: '/quizzes/submissions' },
+    { element: <Dashboard />, path: '/quizzes/dashboard' },
+    // Not Found
     { element: <NotFound />, path: '*' },
   ]
 

--- a/src/constants/menuData.ts
+++ b/src/constants/menuData.ts
@@ -37,10 +37,10 @@ export const menuData: MenuItem[] = [
     menuIcon: TestIcon,
     mainMenu: '쪽지시험 관리',
     subMenu: [
-      { name: '쪽지시험 관리', path: '' },
-      { name: '배포 내역 관리', path: '' },
-      { name: '응시 내역 관리', path: '' },
-      { name: '쪽지시험 대시보드', path: '' },
+      { name: '쪽지시험 관리', path: '/quizzes' },
+      { name: '배포 내역 관리', path: '/quizzes/deployments' },
+      { name: '응시 내역 관리', path: '/quizzes/submissions' },
+      { name: '쪽지시험 대시보드', path: '/quizzes/dashboard' },
     ],
   },
 ]

--- a/src/pages/quizzes/Dashboard.tsx
+++ b/src/pages/quizzes/Dashboard.tsx
@@ -1,0 +1,5 @@
+// 쪽지시험 대시보드
+const Dashboard = () => {
+  return <div>Dashboard</div>
+}
+export default Dashboard

--- a/src/pages/quizzes/Deployments.tsx
+++ b/src/pages/quizzes/Deployments.tsx
@@ -1,0 +1,5 @@
+// 배포내역 관리
+const Deployments = () => {
+  return <div>Deployments</div>
+}
+export default Deployments

--- a/src/pages/quizzes/Quizzes.tsx
+++ b/src/pages/quizzes/Quizzes.tsx
@@ -1,0 +1,5 @@
+// 쪽지시험 관리
+const Quizzes = () => {
+  return <div>Quizzes</div>
+}
+export default Quizzes

--- a/src/pages/quizzes/Submissions.tsx
+++ b/src/pages/quizzes/Submissions.tsx
@@ -1,0 +1,5 @@
+// 응시내역 관리
+const Submissions = () => {
+  return <div>Submissions</div>
+}
+export default Submissions


### PR DESCRIPTION
## #️⃣연관된 이슈

> #56

## 📝작업 내용

> 쪽지시험 페이지 라우팅 추가
- 쪽지시험 관리 : /quizzes
- 배포내역 관리 : /quizzes/deployments
- 응시내역 관리 : /quizzes/submissions
- 쪽지시험 대시보드 : /quizzes/dashboard
- 사이드바에 연결

