### PR TITLE
feat: 배포내역 조회 기능 구현(#93)

### DIFF
--- a/src/components/common/data-table/TableRow.tsx
+++ b/src/components/common/data-table/TableRow.tsx
@@ -19,7 +19,6 @@ export default function TableRow({
   isCheckBox,
   isChecked,
   onToggle,
-  isDeployStatus,
   isTime,
 }: Props) {
   const DATA_KEYS = {
@@ -27,6 +26,9 @@ export default function TableRow({
     DEPLOY_SWITCH: 'deploySwitch',
     CREATED_AT: 'created_at',
     UPDATED_AT: 'updated_at',
+    CREATED_AT_CAMEL: 'createdAt',
+    STARTED_AT: 'startedAt',
+    SUBMITTED_AT: 'submittedAt',
     TYPE: 'type',
     ROLE: 'role',
   } as const
@@ -43,7 +45,7 @@ export default function TableRow({
     STUDENT: 'STUDENT',
   } as const
 
-  const [deployStatus, setDeployStatus] = useState(isDeployStatus)
+  const [deployStatus, setDeployStatus] = useState<boolean>(!!data.deploySwitch)
 
   const handleDeploy = () => {
     setDeployStatus(true)
@@ -166,6 +168,9 @@ export default function TableRow({
                 }
               case DATA_KEYS.CREATED_AT:
               case DATA_KEYS.UPDATED_AT:
+              case DATA_KEYS.CREATED_AT_CAMEL:
+              case DATA_KEYS.STARTED_AT:
+              case DATA_KEYS.SUBMITTED_AT:
                 return formatIsoToDotDateTime(String(value), isTime ?? false)
               default:
                 return value

--- a/src/constants/button/button.ts
+++ b/src/constants/button/button.ts
@@ -8,7 +8,7 @@ export const BUTTON_VARIANTS = {
   VARIANT5:
     ' bg-[#5EB669] text-[#FFFFFF] h-[26px] w-[50px] text-[12px] leading-none',
   VARIANT6: 'bg-[#86838B] text-[#FFFFFF] h-[36px] w-[79px] text-[14px]',
-  VARIANT7: 'bg-[#F3EEFF] text-[#522193] w-[55px] h-[36px] text-[14px]',
+  VARIANT7: 'bg-[#F3EEFF] text-[#522193] w-[135px] h-[36px] text-[14px]',
   VARIANT8:
     'flex items-center justify-between bg-[#F3EEFF] text-[#522193] h-[36px] w-[135px] text-[14px] px-[12px]',
 } as const

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,0 +1,10 @@
+// baseURL
+export const ADMIN_API_BASE_URL = 'http://54.180.237.77/api/v1/admin/'
+
+// 세부 경로
+export const ADMIN_API_PATH = {
+  TEST: 'tests/',
+  SUBJECTS: 'subjects/',
+  TEST_DEPLOYMENTS: 'test-deployments/',
+  TEST_SUBMISSIONS: 'test-submissions/',
+}

--- a/src/pages/quizzes/Deployments.tsx
+++ b/src/pages/quizzes/Deployments.tsx
@@ -16,6 +16,7 @@ import {
 import SearchBar from '@components/common/SearchBar'
 import axios from 'axios'
 import { filterOption } from '@utils/filterOption'
+import { ADMIN_API_BASE_URL, ADMIN_API_PATH } from '@constants/urls'
 
 // 페이지 상수
 const COUNT_LIMIT = 20
@@ -34,7 +35,7 @@ const deploymentHeaders = [
 
 // 공통 API 인스턴스
 const api = axios.create({
-  baseURL: 'http://54.180.237.77/api/v1/admin',
+  baseURL: ADMIN_API_BASE_URL,
   headers: {
     'Content-Type': 'application/json',
     Accept: 'application/json',
@@ -44,7 +45,7 @@ const api = axios.create({
 
 // fetch 함수
 const fetchAPI = async () => {
-  const res = await api.get<DeploymentResponse>('/test-deployments/')
+  const res = await api.get<DeploymentResponse>(ADMIN_API_PATH.TEST_DEPLOYMENTS)
   return res.data.results.map(mapDeployment)
 }
 

--- a/src/pages/quizzes/Deployments.tsx
+++ b/src/pages/quizzes/Deployments.tsx
@@ -1,5 +1,220 @@
-// 배포내역 관리
-const Deployments = () => {
-  return <div>Deployments</div>
+import Button from '@components/common/Button'
+import DataTable from '@components/common/data-table/DataTable'
+import Modal from '@components/common/Modal'
+import DropdownField from '@components/common/DropdownField'
+import Icon from '@components/common/Icon'
+import SearchIcon from '@assets/icons/search.svg?react'
+import { useState, useMemo, useEffect } from 'react'
+import Pagination from '@components/common/data-table/Pagination'
+import { useSort } from '@hooks/data-table/useSort'
+import { usePagination } from '@hooks/data-table/usePagination'
+import {
+  mapDeployment,
+  type Deployment,
+  type DeploymentResponse,
+} from '@custom-types/deployments'
+import SearchBar from '@components/common/SearchBar'
+import axios from 'axios'
+import { filterOption } from '@utils/filterOption'
+
+// 페이지 상수
+const COUNT_LIMIT = 20
+
+// 테이블 헤더
+const deploymentHeaders = [
+  { text: 'ID', dataKey: 'id' },
+  { text: '제목', dataKey: 'testTitle' },
+  { text: '과목명', dataKey: 'subjectTitle' },
+  { text: '과정 | 기수', dataKey: 'courseGeneration' },
+  { text: '응시자 수', dataKey: 'totalParticipants' },
+  { text: '평균 점수', dataKey: 'averageScore' },
+  { text: '생성 일시', dataKey: 'createdAt' },
+  { text: '배포 상태', dataKey: 'deploySwitch' },
+]
+
+// 공통 API 인스턴스
+const api = axios.create({
+  baseURL: 'http://54.180.237.77/api/v1/admin',
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    // Authorization: `Bearer ${access_token}`,
+  },
+})
+
+// fetch 함수
+const fetchAPI = async () => {
+  const res = await api.get<DeploymentResponse>('/test-deployments/')
+  return res.data.results.map(mapDeployment)
 }
+
+const Deployments = () => {
+  // 모달 상태
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  // 필터링 옵션 상태
+  const [selectedCourse, setSelectedCourse] = useState('')
+  const [selectedGeneration, setSelectedGeneration] = useState('')
+  // 검색 상태
+  const [searchKeyword, setSearchKeyword] = useState('')
+
+  const [fetchData, setFetchData] = useState<Deployment[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  // API 호출 (임시)
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const deployments = await fetchAPI()
+        setFetchData(deployments)
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err)
+        } else {
+          console.error('알 수 없는 에러:', err)
+        }
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [])
+
+  // 테이블에 들어갈 데이터
+  const tableData: Deployment[] = useMemo(() => fetchData, [fetchData])
+
+  // 드롭다운 옵션
+  const courseOptions = filterOption(
+    tableData.map((d) => ({ course: d.courseGeneration?.split(' ')[0] })),
+    'course',
+    (val) => `${val} 부트캠프`
+  )
+  const generationOptions = filterOption(
+    tableData.map((d) => ({ generation: d.courseGeneration?.split(' ')[1] })),
+    'generation'
+  )
+
+  // 필터링 데이터 저장
+  const [filteredData, setFilteredData] = useState<Deployment[]>([])
+
+  // 정렬
+  const { sortedData, sortKey, sortOrder, sortByKey } = useSort(filteredData)
+
+  // 페이지네이션
+  const { currentPage, totalPages, paginatedData, goToPage } = usePagination({
+    item: sortedData,
+    count: COUNT_LIMIT,
+  })
+
+  // 필터링 기능
+  const filterHandler = () => {
+    if (!tableData.length) return
+    const result = tableData.filter((item) => {
+      const [course, generation] = item.courseGeneration.split(' ')
+      const isCourseMatch = selectedCourse ? course === selectedCourse : true
+      const isGenMatch = selectedGeneration
+        ? generation === selectedGeneration
+        : true
+      const isKeywordMatch = searchKeyword
+        ? item.subjectTitle.includes(searchKeyword)
+        : true
+      return isCourseMatch && isGenMatch && isKeywordMatch
+    })
+    setFilteredData(result)
+  }
+
+  // 초기 호출
+  useEffect(() => {
+    if (fetchData.length > 0) {
+      setFilteredData(fetchData)
+    }
+  }, [fetchData])
+
+  if (loading)
+    return <div className="h-full text-center text-3xl">Loading...</div>
+  if (error) return <div>에러가 발생했습니다: {error.message}</div>
+
+  return (
+    <div className="min-w-[1600px] p-[30px]">
+      <h2 className="mb-5 text-lg font-semibold">쪽지 시험 배포 내역 조회</h2>
+      <div className="flex justify-between">
+        <SearchBar
+          onSearch={(keyword) => {
+            setSearchKeyword(keyword)
+            filterHandler()
+          }}
+          placeholder="검색어를 입력하세요."
+        ></SearchBar>
+        <Button
+          variant="VARIANT7"
+          className="my-3 flex items-center justify-center gap-3"
+          onClick={() => setIsModalOpen(true)}
+        >
+          <Icon icon={SearchIcon} className="w-[16px]" size={16} />
+          과정별 필터링
+        </Button>
+      </div>
+      {/* 모달 */}
+      <Modal
+        modalId="deploymentFilterModal"
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        className="w-fit min-w-[500px] gap-2"
+        paddingSize={36}
+      >
+        <h3 className="text-lg font-semibold">과정별 필터링</h3>
+        <p className="mb-5 text-sm">필터를 적용할 조건을 선택해주세요.</p>
+        <DropdownField
+          label="과정"
+          id="course"
+          value={selectedCourse}
+          onChange={setSelectedCourse}
+          options={courseOptions}
+        />
+        <DropdownField
+          label="기수"
+          id="generation"
+          value={selectedGeneration}
+          onChange={setSelectedGeneration}
+          options={generationOptions}
+        />
+        <Button
+          className="mt-4 self-end"
+          variant="VARIANT1"
+          onClick={() => {
+            filterHandler()
+            setIsModalOpen(false)
+          }}
+        >
+          조회
+        </Button>
+      </Modal>
+      {/* 테이블 */}
+      <DataTable
+        headerData={deploymentHeaders}
+        tableItem={paginatedData.map((item) => {
+          return {
+            ...item,
+            deploySwitch: item.status === 'Activated',
+          }
+        })}
+        isCheckBox={false}
+        sortKeys={['created_at', 'total_participants', 'average_score']}
+        sortKey={sortKey}
+        sortOrder={sortOrder}
+        sortByKey={sortByKey}
+        isTime
+      />
+      {/* 페이지네이션 */}
+      <div className="pt-8 pb-2">
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          goToPage={goToPage}
+        />
+      </div>
+    </div>
+  )
+}
+
 export default Deployments

--- a/src/types/deployments.ts
+++ b/src/types/deployments.ts
@@ -1,0 +1,39 @@
+export type Deployment = {
+  id: number
+  testTitle: string
+  subjectTitle: string
+  courseGeneration: string
+  totalParticipants: number
+  averageScore: number
+  status: 'Activated' | 'Deactivated'
+  createdAt: string
+}
+
+export type DeploymentResponse = {
+  count: number
+  next: string | null
+  previous: string | null
+  results: {
+    deployment_id: number
+    test_title: string
+    subject_title: string
+    course_generation: string
+    total_participants: number
+    average_score: number
+    status: 'Activated' | 'Deactivated'
+    created_at: string
+  }[]
+}
+
+export const mapDeployment = (
+  d: DeploymentResponse['results'][number]
+): Deployment => ({
+  id: d.deployment_id,
+  testTitle: d.test_title,
+  subjectTitle: d.subject_title,
+  courseGeneration: d.course_generation,
+  totalParticipants: d.total_participants,
+  averageScore: d.average_score,
+  status: d.status,
+  createdAt: d.created_at,
+})

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -2,7 +2,7 @@ import type { SortOrder } from '@hooks/data-table/useSort'
 
 export type TableRowData = {
   id: number // string 제거
-  [key: string]: string | number | string[] | null // 타입추가
+  [key: string]: string | number | string[] | boolean | null | undefined // 타입추가
 }
 
 export type TableHeader = {

--- a/src/utils/filterOption.ts
+++ b/src/utils/filterOption.ts
@@ -1,0 +1,18 @@
+type Option = { label: string; value: string }
+
+export function filterOption<T>(
+  data: T[],
+  key: keyof T,
+  labelFormatter?: (val: string) => string
+): Option[] {
+  const values = Array.from(
+    new Set(data.map((item) => String(item[key] ?? '')).filter(Boolean))
+  )
+  return [
+    { label: '전체 보기', value: '' },
+    ...values.map((val) => ({
+      label: labelFormatter ? labelFormatter(val) : val,
+      value: val,
+    })),
+  ]
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #93

## 📝작업 내용

> 검색, 필터링, 정렬 필터, 페이지네이션 기능을 가진 배포내역 조회 기능 구현

- Deployments.tsx : 배포내역 조회 페이지 (axios로 데이터 fetch 포함)
- deployments.ts : API 응답 타입 정의 및 매핑 
- filterOption.ts : 필터링 드롭다운 내 옵션 배열 생성 유틸
- TableRow.tsx, table.ts : 배포 스위치 동작을 위해 TableRow에 상태 초기화 추가, RowData에 boolean 타입 확장
- button.ts : 버튼 스타일 VARIANT7의 너비 수정

