### PR TITLE
feat: 과목 목록 조회 (#106)

### DIFF
--- a/src/components/common/data-table/DataTable.tsx
+++ b/src/components/common/data-table/DataTable.tsx
@@ -12,6 +12,7 @@ export default function DataTable({
   sortOrder,
   sortByKey,
   isTime,
+  renderMap,
 }: DataTableProps) {
   const { checkedItems, toggleItem, toggleAll, isAllChecked } = useSelection()
 
@@ -47,6 +48,7 @@ export default function DataTable({
               isChecked={checkedItems.has(String(item.id))}
               onToggle={(checked) => toggleItem(String(item.id), checked)}
               isTime={isTime}
+              renderMap={renderMap}
             />
           ))}
 

--- a/src/components/common/data-table/TableRow.tsx
+++ b/src/components/common/data-table/TableRow.tsx
@@ -11,6 +11,9 @@ type Props = {
   onToggle: (checked: boolean) => void
   isDeployStatus?: boolean
   isTime?: boolean
+  renderMap?: {
+    [key: string]: (value: unknown, rowData: TableRowData) => React.ReactNode
+  }
 }
 
 export default function TableRow({
@@ -20,6 +23,7 @@ export default function TableRow({
   isChecked,
   onToggle,
   isTime,
+  renderMap,
 }: Props) {
   const DATA_KEYS = {
     DEPLOY: 'deploy',
@@ -27,6 +31,7 @@ export default function TableRow({
     CREATED_AT: 'created_at',
     UPDATED_AT: 'updated_at',
     CREATED_AT_CAMEL: 'createdAt',
+    UPDATED_AT_CAMEL: 'updatedAt',
     STARTED_AT: 'startedAt',
     SUBMITTED_AT: 'submittedAt',
     TYPE: 'type',
@@ -77,6 +82,9 @@ export default function TableRow({
         <td key={i} className="w-[150px] p-2 text-[#666]">
           {(() => {
             const value = data[header.dataKey]
+            // renderMap으로 커스텀 스타일 적용
+            const customRender = renderMap?.[header.dataKey]
+            if (customRender) return customRender(value, data)
 
             // 공백 대시 처리
             const isValueEmpty =
@@ -169,6 +177,7 @@ export default function TableRow({
               case DATA_KEYS.CREATED_AT:
               case DATA_KEYS.UPDATED_AT:
               case DATA_KEYS.CREATED_AT_CAMEL:
+              case DATA_KEYS.UPDATED_AT_CAMEL:
               case DATA_KEYS.STARTED_AT:
               case DATA_KEYS.SUBMITTED_AT:
                 return formatIsoToDotDateTime(String(value), isTime ?? false)

--- a/src/pages/courses/Subjects.tsx
+++ b/src/pages/courses/Subjects.tsx
@@ -1,5 +1,127 @@
+import DataTable from '@components/common/data-table/DataTable'
+import Pagination from '@components/common/data-table/Pagination'
+import { ADMIN_API_BASE_URL, ADMIN_API_PATH } from '@constants/urls'
+import {
+  mapSubject,
+  type Subject,
+  type SubjectResponse,
+} from '@custom-types/subjects'
+import { usePagination } from '@hooks/data-table/usePagination'
+import { cn } from '@utils/cn'
+import axios from 'axios'
+import { useEffect, useMemo, useState } from 'react'
+
+// 페이지 상수
+const COUNT_LIMIT = 20
+
+// 테이블 헤더
+const subjectHeader = [
+  { text: 'ID', dataKey: 'id' },
+  { text: '과목명', dataKey: 'title' },
+  { text: '수강일수', dataKey: 'days' },
+  { text: '시수', dataKey: 'hours' },
+  { text: '과정', dataKey: 'courseName' },
+  { text: '상태', dataKey: 'isActive' },
+  { text: '등록 일시', dataKey: 'createdAt' },
+  { text: '수정 일시', dataKey: 'updatedAt' },
+]
+
+// 공통 API 인스턴스
+const api = axios.create({
+  baseURL: ADMIN_API_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    // Authorization: `Bearer ${access_token}`,
+  },
+})
+
+// fetch 함수
+const fetchAPI = async () => {
+  const res = await api.get<SubjectResponse>(ADMIN_API_PATH.SUBJECTS)
+  console.log(res)
+  return res.data.results.map(mapSubject)
+}
+
 // 과목 관리
 const Subjects = () => {
-  return <div>Subjects</div>
+  const [fetchData, setFetchData] = useState<Subject[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  // API 호출 (임시)
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const subjects = await fetchAPI()
+        setFetchData(subjects)
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err)
+        } else {
+          console.error('알 수 없는 에러:', err)
+        }
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [])
+
+  // 테이블에 들어갈 데이터
+  const tableData: Subject[] = useMemo(() => {
+    return fetchData.map((subject) => ({
+      ...subject,
+      statusText: subject.isActive ? 'Activated' : 'Deactivated',
+    }))
+  }, [fetchData])
+
+  // 페이지네이션
+  const { currentPage, totalPages, paginatedData, goToPage } = usePagination({
+    item: tableData,
+    count: COUNT_LIMIT,
+  })
+  if (loading)
+    return <div className="h-full text-center text-3xl">Loading...</div>
+  if (error) return <div>에러가 발생했습니다: {error.message}</div>
+
+  return (
+    <div className="min-w-[1600px] p-[30px]">
+      <h2 className="mb-5 text-lg font-semibold">과목 조회</h2>
+      {/* 테이블 */}
+      <DataTable
+        headerData={subjectHeader}
+        tableItem={paginatedData}
+        renderMap={{
+          isActive: (value) => (
+            <span
+              className={cn(
+                'inline-block rounded-md px-2 py-1 text-xs font-semibold',
+                value
+                  ? 'bg-option-green/15 text-option-green'
+                  : 'bg-option-red/15 text-option-red'
+              )}
+            >
+              {value ? 'Activated' : 'Deactivated'}
+            </span>
+          ),
+        }}
+        isCheckBox={false}
+        sortKeys={[]}
+        isTime
+        sortKey={null}
+        sortOrder={'asc'}
+        sortByKey={() => {}}
+      />
+      {/* 페이지네이션 */}
+      <div className="pt-8 pb-2">
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          goToPage={goToPage}
+        />
+      </div>
+    </div>
+  )
 }
 export default Subjects

--- a/src/types/subjects.ts
+++ b/src/types/subjects.ts
@@ -1,0 +1,39 @@
+export type RawSubject = {
+  id: number
+  title: string
+  number_of_days: number
+  number_of_hours: number
+  course_name: string
+  status: boolean
+  created_at: string
+  updated_at: string
+}
+
+export type Subject = {
+  id: number
+  title: string
+  days: number
+  hours: number
+  courseName: string
+  isActive: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export type SubjectResponse = {
+  count: number
+  next: string | null
+  previous: string | null
+  results: RawSubject[]
+}
+
+export const mapSubject = (raw: RawSubject): Subject => ({
+  id: raw.id,
+  title: raw.title,
+  days: raw.number_of_days,
+  hours: raw.number_of_hours,
+  courseName: raw.course_name,
+  isActive: raw.status,
+  createdAt: raw.created_at,
+  updatedAt: raw.updated_at,
+})

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -23,6 +23,9 @@ export type DataTableProps = {
   sortOrder: SortOrder
   sortByKey: (key: string) => void
   isTime: boolean
+  renderMap?: {
+    [key: string]: (value: unknown, rowData: TableRowData) => React.ReactNode
+  }
 }
 
 export type Pagination = {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #106

## 📝작업 내용

> 과목 목록을 커서 기반 페이지네이션(20개 단위)으로 조회
- Subjects.tsx : 과목 목록 조회 페이지
- subjects.ts : API 응답 타입 정의 및 매핑
> 테이블 컴포넌트에 renderMap 추가 (특정 컬럼에 커스텀 렌더링이 가능)
- DataTable.tsx : `renderMap` prop을 TableRow에 전달하는 로직 추가 
- TableRow.tsx : `renderMap` prop으로 커스텀 렌더링 처리 추가
- table.ts : `renderMap` 관련 정의 추가
