### PR TITLE
feat: quizzes 페이지와 상세조회 모달 연결(#126)

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -8,7 +8,7 @@ type ButtonVariant = keyof typeof BUTTON_VARIANTS
 
 type ButtonProps = {
   children: React.ReactNode
-  onClick?: () => void
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
   disabled?: boolean
   variant?: ButtonVariant
   className?: string

--- a/src/components/common/data-table/TableRow.tsx
+++ b/src/components/common/data-table/TableRow.tsx
@@ -1,4 +1,3 @@
-import Button from '@components/common/Button'
 import type { TableHeader, TableRowData } from '@custom-types/table'
 import { cn } from '@utils/cn'
 import { formatIsoToDotDateTime } from '@utils/formatDate'
@@ -53,9 +52,6 @@ export default function TableRow({
 
   const [deployStatus, setDeployStatus] = useState<boolean>(!!data.deploySwitch)
 
-  const handleClick = () => {
-    onClick?.(data)
-  }
   const toggleSwitch = () => {
     setDeployStatus((prev) => !prev)
   }
@@ -100,12 +96,6 @@ export default function TableRow({
             }
 
             switch (header.dataKey) {
-              case DATA_KEYS.DEPLOY:
-                return (
-                  <Button variant="VARIANT5" onClick={handleClick}>
-                    배포
-                  </Button>
-                )
               case DATA_KEYS.DEPLOY_SWITCH:
                 return (
                   <label className="relative inline-flex cursor-pointer items-center">
@@ -117,9 +107,9 @@ export default function TableRow({
                     />
                     <div
                       className={cn(
-                        `peer peer-checked:bg-[#5EB669] peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-[#5EB669]`,
+                        `peer peer-checked:bg-[#5EB669] peer-focus:ring-2 peer-focus:ring-[#5EB669] peer-focus:outline-none`,
                         `peer-checked:after:translate-x-full peer-checked:after:border-[#F5F5F5]`,
-                        `after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full`,
+                        `after:absolute after:top-[2px] after:left-[2px] after:h-5 after:w-5 after:rounded-full`,
                         `after:border after:border-[#F5F5F5] after:bg-white after:transition-all after:content-['']`,
                         `h-6 w-11 rounded-full bg-[#DDDDDD]`
                       )}

--- a/src/components/quizzes/detail-modal/DetailModal.tsx
+++ b/src/components/quizzes/detail-modal/DetailModal.tsx
@@ -2,7 +2,12 @@ import { useState } from 'react'
 import QuizzesWrapper from '@components/quizzes/detail-modal/components/QuizzesWrapper'
 import { type Question, type QuizData } from '@custom-types/quizzes/quizTypes'
 
-function DetailModal() {
+type DetailModalProps = {
+  testId: number
+}
+
+function DetailModal({ testId }: DetailModalProps) {
+  console.log(testId)
   // TODO: 임시 데이터, 나중에 수정
   const quizData: QuizData = {
     id: 4,
@@ -57,10 +62,10 @@ function DetailModal() {
       {
         id: 105,
         type: 'fill_in_blank',
-        question: '자료구조에서 큐에 해당하는 구조를 입력하세요.',
+        question: '자료구조에서 큐는 ____ 구조입니다.',
         point: 5,
-        prompt: '자료구조에서 큐는 (A)____ 구조입니다.',
-        options: null,
+        prompt: '자료구조에서 큐는 ____ 구조입니다.',
+        options: [],
         answer: ['FIFO'],
         explanation: '큐는 선입선출(FIFO) 구조입니다.',
       },
@@ -70,7 +75,7 @@ function DetailModal() {
         question: 'HTTP의 약어는 무엇인가요?',
         point: 5,
         prompt: '알파벳 4자로 입력하세요',
-        options: null,
+        options: [],
         answer: 'HyperText Transfer Protocol',
         explanation: 'HTTP는 웹 통신에 사용되는 프로토콜입니다.',
       },

--- a/src/pages/quizzes/Quizzes.tsx
+++ b/src/pages/quizzes/Quizzes.tsx
@@ -16,6 +16,7 @@ import type { SchedulePayload } from '@custom-types/createSchedule'
 import api from '@api/axiosInstance'
 import AddExamModal from '@components/quizzes/add-exam-modal/AddExamModal'
 import CourseFilterModal from '@components/quizzes/course-filter-modal/CourseFilterModal'
+import DetailModal from '@components/quizzes/detail-modal/DetailModal'
 
 // 표제목 상수화
 const TableHeaderItem = [
@@ -40,6 +41,8 @@ const Quizzes = () => {
   const [error, setError] = useState<Error | null>(null)
   const [isOpen, setIsOpen] = useState(false)
   const [isFilterModalOpen, setIsFilterModalOpen] = useState(false)
+  const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
+  const [selectedTestId, setSelectedTestId] = useState<number | null>(null)
 
   const { isModalOpen, selectedQuiz, openScheduleModal, closeScheduleModal } =
     useScheduleStore()
@@ -55,13 +58,32 @@ const Quizzes = () => {
     { id: 10, name: '10기' },
   ]
 
-  // 배포 버튼 클릭 핸들러 추가
-  const handleDeployClick = (quizData: TableRowData) => {
+  const handleTableClick = (quizData: TableRowData) => {
+    setSelectedTestId(Number(quizData.id))
+    setIsDetailModalOpen(true)
+  }
+
+  const handleDeployButtonClick = (quizData: TableRowData) => {
     openScheduleModal({
       test_id: Number(quizData.id),
       test_title: String(quizData.title),
       subject_title: String(quizData.subject_name),
     })
+  }
+
+  const renderMap = {
+    deploy: (_: unknown, rowData: TableRowData) => (
+      <Button
+        variant="VARIANT5"
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+          e.stopPropagation()
+
+          handleDeployButtonClick(rowData)
+        }}
+      >
+        배포
+      </Button>
+    ),
   }
 
   // 스케줄 제출 핸들러 추가
@@ -169,6 +191,11 @@ const Quizzes = () => {
   if (loading) return <div>Loading...</div>
   if (error) return <div>에러가 발생했습니다: {error.message}</div>
 
+  if (isDetailModalOpen && selectedTestId !== null) {
+    // 시험 상세정보 조회/수정/삭제 모달
+    return <DetailModal testId={selectedTestId} />
+  }
+
   return (
     <div className="p-8">
       <h2 className="mb-[26px] text-[18px] font-semibold">쪽지시험 조회</h2>
@@ -199,7 +226,8 @@ const Quizzes = () => {
         sortOrder={sortOrder} // 현재 정렬 방향 전달
         sortByKey={sortByKey} // 정렬 함수 전달
         isTime // 시간 표시 여부
-        onClick={handleDeployClick} // 배포 버튼 클릭 핸들러
+        onClick={handleTableClick}
+        renderMap={renderMap}
       />
 
       <div className="mt-[80px] flex justify-center">

--- a/src/types/quizzes/quizTypes.ts
+++ b/src/types/quizzes/quizTypes.ts
@@ -52,7 +52,7 @@ export type ShortAnswerQuestion = {
   question: string
   point: number
   prompt: string
-  options: null
+  options: []
   answer: string
   explanation: string
 }
@@ -63,7 +63,7 @@ export type FillInBlankQuestion = {
   question: string
   point: number
   prompt: string
-  options: null
+  options: []
   answer: string[]
   explanation: string
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #126

## 📝작업 내용

> quizzes 페이지와 상세조회 모달 연결
- Button의 onClick 타입 변경
- TableRow에서 배포 버튼 분리
- DetailModal 임시 데이터 최신화
- quizTypes 최신화

