### PR TITLE
feat: 응시내역 조회 기능 API 연결

### DIFF
--- a/src/api/submissions/index.ts
+++ b/src/api/submissions/index.ts
@@ -1,0 +1,8 @@
+import api from '@api/instance/axiosInstance'
+import { ADMIN_API_PATH } from '@constants/urls'
+import type { SubmissionResponse } from '@custom-types/submission'
+
+export const fetchSubmissions = async (): Promise<SubmissionResponse> => {
+  const res = await api.get(ADMIN_API_PATH.TEST_SUBMISSIONS)
+  return res.data
+}

--- a/src/components/common/data-table/TableRow.tsx
+++ b/src/components/common/data-table/TableRow.tsx
@@ -32,7 +32,7 @@ export default function TableRow({
     DEPLOY_SWITCH: 'deploySwitch',
     CREATED_AT: 'created_at',
     UPDATED_AT: 'updated_at',
-    STARTED_AT: 'startedAt',
+    STARTED_AT: 'started_at',
     SUBMITTED_AT: 'submittedAt',
     TYPE: 'type',
     ROLE: 'role',

--- a/src/hooks/queries/useSubmissions.ts
+++ b/src/hooks/queries/useSubmissions.ts
@@ -1,0 +1,10 @@
+import { fetchSubmissions } from '@api/submissions'
+import type { SubmissionResponse } from '@custom-types/submission'
+import { useQuery } from '@tanstack/react-query'
+
+export const useSubmissions = () => {
+  return useQuery<SubmissionResponse>({
+    queryKey: ['submission'],
+    queryFn: fetchSubmissions,
+  })
+}

--- a/src/pages/courses/Subjects.tsx
+++ b/src/pages/courses/Subjects.tsx
@@ -1,13 +1,13 @@
+import Button from '@components/common/Button'
 import DataTable from '@components/common/data-table/DataTable'
 import Pagination from '@components/common/data-table/Pagination'
+import AddSubjectsModal from '@components/subject/add-subject-modal/AddSubjectModal'
 import SubjectDetailModal from '@components/subject/detail-modal/SubjectDetailModal'
 import { type Subject } from '@custom-types/subjects'
+import { useServerPagination } from '@hooks/data-table/usePagination'
 import { useSubjects } from '@hooks/queries/useSubjects'
 import { renderStatus } from '@utils/renderStatus'
-import { useState, useEffect } from 'react'
-import { useServerPagination } from '@hooks/data-table/usePagination'
-import Button from '@components/common/Button'
-import AddSubjectsModal from '@components/subject/add-subject-modal/AddSubjectModal'
+import { useEffect, useState } from 'react'
 
 // 페이지 상수
 const COUNT_LIMIT = 10
@@ -44,13 +44,11 @@ const Subjects = () => {
     }
   }, [data?.count, setTotalCount])
 
-  // 모달 상태
+  // 상세조회 모달
   const [selectedSubject, setSelectedSubject] = useState<Subject | null>(null)
-  const [isModalOpen, setIsModalOpen] = useState(false)
-
-  const openModal = () => {
-    setIsModalOpen(true)
-  }
+  const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
+  // 등록 모달
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false)
 
   if (isLoading)
     return <div className="h-full text-center text-3xl">Loading...</div>
@@ -66,7 +64,7 @@ const Subjects = () => {
           tableItem={data?.results ?? []}
           onClick={(subject) => {
             setSelectedSubject(subject as Subject)
-            setIsModalOpen(true)
+            setIsDetailModalOpen(true)
           }}
           renderMap={{
             status: renderStatus,
@@ -81,9 +79,9 @@ const Subjects = () => {
         {/* 모달 */}
         <SubjectDetailModal
           subject={selectedSubject as Subject}
-          isOpen={isModalOpen}
+          isOpen={isDetailModalOpen}
           onClose={() => {
-            setIsModalOpen(false)
+            setIsDetailModalOpen(false)
             setSelectedSubject(null)
           }}
         />
@@ -97,11 +95,11 @@ const Subjects = () => {
               goToPage={goToPage}
             />
           </div>
-          <Button onClick={openModal}>등록</Button>
+          <Button onClick={() => setIsAddModalOpen(true)}>등록</Button>
         </div>
       </div>
       {/* 과목을 추가할 때 사용하는 모달 */}
-      <AddSubjectsModal isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
+      <AddSubjectsModal isOpen={isAddModalOpen} setIsOpen={setIsAddModalOpen} />
     </>
   )
 }

--- a/src/pages/quizzes/Submissions.tsx
+++ b/src/pages/quizzes/Submissions.tsx
@@ -1,62 +1,20 @@
+import SearchIcon from '@assets/icons/search.svg?react'
 import Button from '@components/common/Button'
 import DataTable from '@components/common/data-table/DataTable'
-import SearchIcon from '@assets/icons/search.svg?react'
-import Icon from '@components/common/Icon'
-import {
-  mapSubmission,
-  type Submission,
-  type SubmissionResponse,
-} from '@custom-types/submission'
-import Modal from '@components/common/Modal'
-import { useMemo, useState } from 'react'
 import Pagination from '@components/common/data-table/Pagination'
-import { useSort } from '@hooks/data-table/useSort'
-import { useClientPagination } from '@hooks/data-table/usePagination'
 import DropdownField from '@components/common/DropdownField'
+import Icon from '@components/common/Icon'
+import Modal from '@components/common/Modal'
+import type { TableRowData } from '@custom-types/table'
+import { useClientPagination } from '@hooks/data-table/usePagination'
+import { useSort } from '@hooks/data-table/useSort'
+import { useSubmissions } from '@hooks/queries/useSubmissions'
+import { filterOption } from '@utils/filterOption'
+import { useEffect, useMemo, useState } from 'react'
+import { mapSubmission } from '../../types/submission'
 
 // 페이지 상수 추가
 const COUNT_LIMIT = 20
-
-// 목업 데이터
-const mockSubmissions = {
-  count: 2,
-  next: null,
-  previous: null,
-  results: [
-    {
-      submission_id: 101,
-      student: {
-        nickname: 'codeMaster',
-        name: '홍길동',
-        generation: '프론트엔드 5기',
-      },
-      test: {
-        title: 'HTML 기초 테스트',
-        subject_title: '웹프로그래밍',
-      },
-      score: 85,
-      cheating_count: 1,
-      started_at: '2025-06-21T09:01:00',
-      submitted_at: '2025-06-21T09:29:00',
-    },
-    {
-      submission_id: 102,
-      student: {
-        nickname: 'devStar',
-        name: '김영희',
-        generation: '백엔드 4기',
-      },
-      test: {
-        title: 'JavaScript 테스트',
-        subject_title: '프론트엔드',
-      },
-      score: 92,
-      cheating_count: 0,
-      started_at: '2025-06-20T13:00:00',
-      submitted_at: '2025-06-20T13:29:00',
-    },
-  ],
-}
 
 // 테이블 헤더
 const submissionHeaders = [
@@ -65,11 +23,16 @@ const submissionHeaders = [
   { text: '과목명', dataKey: 'subject' },
   { text: '닉네임', dataKey: 'nickname' },
   { text: '이름', dataKey: 'name' },
-  { text: '과정 | 기수', dataKey: 'generation' },
-  { text: '부정행위 수', dataKey: 'cheatingCount' },
+  {
+    text: '과정 | 기수',
+    dataKey: 'generation',
+    render: (row: { course: string; generation: number }) =>
+      `${row.course} ${row.generation}기`,
+  },
+  { text: '부정행위 수', dataKey: 'cheating_count' },
   { text: '점수', dataKey: 'score' },
-  { text: '시험 참가 일시', dataKey: 'startedAt' },
-  { text: '시험 종료 일시', dataKey: 'submittedAt' },
+  { text: '시험 참가 일시', dataKey: 'started_at' },
+  { text: '시험 종료 일시', dataKey: 'created_at' },
 ]
 
 const Submissions = () => {
@@ -80,35 +43,31 @@ const Submissions = () => {
   const [selectedGeneration, setSelectedGeneration] = useState('')
   const [selectedSubject, setSelectedSubject] = useState('')
 
+  // React Query로 fetch
+  const { data, isLoading, error } = useSubmissions()
+
+  const tableData = useMemo(() => {
+    if (!data?.data) return []
+    return mapSubmission(data.data)
+  }, [data])
+
   // 드롭다운 옵션
-  const courseOptions = [
-    { label: '전체 보기', value: '' },
-    { label: '프론트엔드 부트캠프', value: '프론트엔드' },
-    { label: '백엔드 부트캠프', value: '백엔드' },
-  ]
-  const generationOptions = [
-    { label: '전체 보기', value: '' },
-    { label: '4기', value: '4기' },
-    { label: '5기', value: '5기' },
-    { label: '6기', value: '6기' },
-    { label: '7기', value: '7기' },
-    { label: '8기', value: '8기' },
-    { label: '9기', value: '9기' },
-  ]
-  const subjectOptions = [
-    { label: '전체 보기', value: '' },
-    { label: '웹 프로그래밍', value: '웹프로그래밍' },
-    { label: '프론트엔드', value: '프론트엔드' },
-  ]
-  // 테이블 데이터
-  const rawData: SubmissionResponse = mockSubmissions
-  const tableData: Submission[] = useMemo(
-    () => rawData.results.map(mapSubmission),
-    [rawData.results]
+  const courseOptions = filterOption(
+    tableData.map((d) => ({ course: d.course })),
+    'course'
+  )
+  const generationOptions = filterOption(
+    tableData.map((d) => ({ generation: d.generation })),
+    'generation',
+    (val) => `${val}기`
+  )
+  const subjectOptions = filterOption(
+    tableData.map((d) => ({ subject: d.subject })),
+    'subject'
   )
 
   // 필터링 데이터 저장
-  const [filteredData, setFilteredData] = useState<Submission[]>(tableData)
+  const [filteredData, setFilteredData] = useState<TableRowData[]>(tableData)
 
   // 정렬
   const { sortedData, sortKey, sortOrder, sortByKey } = useSort(filteredData)
@@ -123,10 +82,11 @@ const Submissions = () => {
   // 필터링 기능
   const filterHandler = () => {
     const result = tableData.filter((item) => {
-      const [course, generation] = item.generation.split(' ')
-      const isCourseMatch = selectedCourse ? course === selectedCourse : true
+      const isCourseMatch = selectedCourse
+        ? item.course === selectedCourse
+        : true
       const isGenMatch = selectedGeneration
-        ? generation === selectedGeneration
+        ? item.generation === selectedGeneration
         : true
       const isSubjectMatch = selectedSubject
         ? item.subject === selectedSubject
@@ -137,90 +97,98 @@ const Submissions = () => {
     setIsModalOpen(false)
   }
 
+  // 필터링될때마다 동기화되도록
+  useEffect(() => {
+    setFilteredData(tableData)
+  }, [tableData])
+
+  if (isLoading)
+    return <div className="h-full text-center text-3xl">Loading...</div>
+  if (error) return <div>에러가 발생했습니다: {error.message}</div>
+
   return (
-    <section className="h-full bg-[#f9f9f9] px-3 py-11">
-      <div className="flex flex-col bg-white px-8 py-10">
-        <h2 className="text-lg font-semibold">쪽지 시험 응시 내역 조회</h2>
-        <div className="self-end">
-          <Button
-            variant="VARIANT7"
-            className="my-3 flex items-center justify-center gap-3 whitespace-nowrap"
-            onClick={() => setIsModalOpen(true)}
-          >
-            <Icon icon={SearchIcon} className="w-[16px]" size={16} />
-            과정별 필터링
-          </Button>
-        </div>
-        {/* 모달 */}
-        <Modal
-          modalId={'filterModal'}
-          isOpen={isModalOpen}
-          onClose={() => setIsModalOpen(false)}
-          className="w-fit min-w-[500px] gap-2"
-          paddingSize={36}
+    <div className="px-8 py-10">
+      <h2 className="text-lg font-semibold">쪽지 시험 응시 내역 조회</h2>
+      <div className="self-end">
+        <Button
+          variant="VARIANT7"
+          className="my-3 flex items-center justify-center gap-3 whitespace-nowrap"
+          onClick={() => setIsModalOpen(true)}
         >
-          <h3 className="text-lg font-semibold">과정별 필터링</h3>
-          <p className="mb-5 text-sm">
-            필터를 적용할 과정과 기수를 선택해주세요.
-          </p>
-          {/* 필터링 드롭다운 */}
-          <DropdownField
-            label="과정"
-            id="course"
-            value={selectedCourse}
-            onChange={setSelectedCourse}
-            options={courseOptions}
-          />
-          <DropdownField
-            label="기수"
-            id="generation"
-            value={selectedGeneration}
-            onChange={setSelectedGeneration}
-            options={generationOptions}
-          />
-          <DropdownField
-            label="과목"
-            id="subject"
-            value={selectedSubject}
-            onChange={setSelectedSubject}
-            options={subjectOptions}
-          />
-          <p className="py-5">
-            현재 선택된 필터 항목은
-            <span className="px-1 font-semibold text-primary-600">
-              {selectedCourse} {selectedGeneration} &gt; {selectedSubject}
-            </span>
-            입니다.
-          </p>
-          <Button
-            className="self-end whitespace-nowrap"
-            variant="VARIANT1"
-            onClick={filterHandler}
-          >
-            조회
-          </Button>
-        </Modal>
-        {/* 리스트 테이블 */}
-        <DataTable
-          headerData={submissionHeaders}
-          tableItem={paginatedData}
-          isCheckBox={false}
-          sortKeys={['score', 'submittedAt']}
-          sortKey={sortKey}
-          sortOrder={sortOrder}
-          sortByKey={sortByKey}
-          isTime={false}
-        />
-        {/* 페이지네이션 */}
-        <div className="pt-8 pb-2">
-          <Pagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            goToPage={goToPage}
-          />
-        </div>
+          <Icon icon={SearchIcon} className="w-[16px]" size={16} />
+          과정별 필터링
+        </Button>
       </div>
-    </section>
+      {/* 모달 */}
+      <Modal
+        modalId={'filterModal'}
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        className="w-fit min-w-[500px] gap-2"
+        paddingSize={36}
+      >
+        <h3 className="text-lg font-semibold">과정별 필터링</h3>
+        <p className="mb-5 text-sm">
+          필터를 적용할 과정과 기수를 선택해주세요.
+        </p>
+        {/* 필터링 드롭다운 */}
+        <DropdownField
+          label="과정"
+          id="course"
+          value={selectedCourse}
+          onChange={setSelectedCourse}
+          options={courseOptions}
+        />
+        <DropdownField
+          label="기수"
+          id="generation"
+          value={selectedGeneration}
+          onChange={setSelectedGeneration}
+          options={generationOptions}
+        />
+        <DropdownField
+          label="과목"
+          id="subject"
+          value={selectedSubject}
+          onChange={setSelectedSubject}
+          options={subjectOptions}
+        />
+        <p className="py-5">
+          현재 선택된 필터 항목은
+          <span className="px-1 font-semibold text-primary-600">
+            {selectedCourse} {selectedGeneration && `${selectedGeneration}기`}
+            &nbsp; &gt; {selectedSubject}
+          </span>
+          입니다.
+        </p>
+        <Button
+          className="self-end whitespace-nowrap"
+          variant="VARIANT1"
+          onClick={filterHandler}
+        >
+          조회
+        </Button>
+      </Modal>
+      {/* 리스트 테이블 */}
+      <DataTable
+        headerData={submissionHeaders}
+        tableItem={paginatedData}
+        isCheckBox={false}
+        sortKeys={['score', 'submittedAt']}
+        sortKey={sortKey}
+        sortOrder={sortOrder}
+        sortByKey={sortByKey}
+        isTime
+      />
+      {/* 페이지네이션 */}
+      <div className="pt-8 pb-2">
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          goToPage={goToPage}
+        />
+      </div>
+    </div>
   )
 }
 export default Submissions

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -1,51 +1,52 @@
-export type Submission = {
-  id: number
-  name: string
-  nickname: string
-  generation: string
-  title: string
-  subject: string
-  score: number
-  cheatingCount: number
-  startedAt: string
-  submittedAt: string
-}
+import type { TableRowData } from '@custom-types/table'
 
 // 단일 항목
-export type SubmissionResult = {
-  submission_id: number
+export type Submission = {
+  id: number
+  deployment: {
+    test: {
+      subject: {
+        title: string
+      }
+      title: string
+    }
+    generation: {
+      course: {
+        name: string
+      }
+      number: number
+    }
+  }
   student: {
-    nickname: string
-    name: string
-    generation: string
+    user: {
+      name: string
+      nickname: string
+    }
   }
-  test: {
-    title: string
-    subject_title: string
-  }
-  score: number
   cheating_count: number
+  score: number
   started_at: string
-  submitted_at: string
+  created_at: string
 }
 
 // API 응답 타입
 export type SubmissionResponse = {
-  count: number
-  next: string | null
-  previous: string | null
-  results: SubmissionResult[]
+  message: string
+  data: Submission[]
 }
 
-export const mapSubmission = (s: SubmissionResult): Submission => ({
-  id: s.submission_id,
-  name: s.student.name,
-  nickname: s.student.nickname,
-  generation: s.student.generation,
-  title: s.test.title,
-  subject: s.test.subject_title,
-  score: s.score,
-  cheatingCount: s.cheating_count,
-  startedAt: s.started_at,
-  submittedAt: s.submitted_at,
-})
+export const mapSubmission = (data: Submission[]): TableRowData[] => {
+  return data.map((item) => ({
+    id: item.id,
+    title: item.deployment.test.title,
+    subject: item.deployment.test.subject.title,
+    nickname: item.student.user.nickname,
+    name: item.student.user.name,
+    course: item.deployment.generation.course.name,
+    generation: item.deployment.generation.number,
+    cheating_count: item.cheating_count,
+    score: item.score,
+    started_at: item.started_at,
+    created_at: item.created_at,
+  }))
+}


### PR DESCRIPTION

## #️⃣연관된 이슈

> #152

## 📝작업 내용

> 응시내역 조회 api 연결
- submissions/index.ts : fetchSubmissions 함수 추가
- hooks/queries/useSubmission.ts 리액트 쿼리 사용 훅
- TableRow.tsx : 스네이크 케이스로 변경해 기존 카멜 케이스 제거
  - 다른 페이지에서 사용 안하고 있음을 확인
- Submission.tsx : 목업 제거 후 API 연동으로 전환
- types/submisson.ts : 기존 타입과 구조가 일부 바뀌어 수정
- Subject.tsx : 등록 모달과 상세 조회 모달의 상태 분리 
