### PR TITLE
fix: 점수 제한 복구(#165)

### DIFF
--- a/src/components/quizzes/detail-modal/DetailModal.tsx
+++ b/src/components/quizzes/detail-modal/DetailModal.tsx
@@ -17,7 +17,7 @@ type DetailModalProps = {
 }
 
 const MAX_QUIZ_COUNT = 10
-const MAX_QUIZ_SCORE_SUM = 5
+const MAX_QUIZ_SCORE_SUM = 100
 
 function DetailModal({ testId, onClose, fetchQuizzes }: DetailModalProps) {
   const [quizData, setQuizData] = useState<QuizData | null>(null)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #165

## 📝작업 내용

> 퀴즈 페이지의 점수 제한 복구
- DetailModal의 MAX_QUIZ_SCORE_SUM을 100으로 복구

